### PR TITLE
Adding capability to load references for mongo entities.

### DIFF
--- a/src/__spec__/helpers/dummy/dummy-repository.ts
+++ b/src/__spec__/helpers/dummy/dummy-repository.ts
@@ -1,7 +1,9 @@
 import { EntityRepositoryBase } from "@app/repository/mongo/entities/entity-repository-base";
+import { IEntityRepositoryReferencePopulator } from '../../../repository/mongo/entities/references/ientity-repository-reference-populator';
 import { DummyModel } from "./models/dummy-model";
 
 export class DummyRepository extends EntityRepositoryBase<DummyModel> {
+  protected references: IEntityRepositoryReferencePopulator<DummyModel>[] = null;
   protected readonly collectionName: string = "Dummies";
   protected readonly factory: new () => DummyModel = DummyModel;
 }

--- a/src/__spec__/repository/mongo/crop/crop-origin-reference-populator.spec.ts
+++ b/src/__spec__/repository/mongo/crop/crop-origin-reference-populator.spec.ts
@@ -1,0 +1,65 @@
+import { CropOriginReferencePopulator } from '@app/repository/mongo/crop/crop-origin-reference-populator';
+import { Origin } from '@common/models/entities/origin/origin';
+import { InMemoryMongoHelper } from '@app/__spec__/helpers/mongo';
+import { random } from 'faker';
+import { OriginRepository } from '@app/repository/mongo/origin/origin-repository';
+import { CropRepository } from '@app/repository/mongo/crop/crop-repository';
+import { Crop } from '@common/models/entities/crop/crop';
+
+const dbHelper = new InMemoryMongoHelper();
+
+beforeAll(async () => {
+  await dbHelper.start();
+});
+
+afterAll(async () => {
+  await dbHelper.cleanup();
+  await dbHelper.stop();
+});
+
+test(`It should successfully link a reference to an ${Origin.name} entity that is in the database and populate it`, async () => {
+  const originRepo = new OriginRepository(dbHelper.db);
+  const cropRepo = new CropRepository(dbHelper.db);
+  
+  const origin = new Origin();
+  origin.altitude = random.number();
+  origin.country = random.word();
+  origin.estate = random.word();
+  
+  const originId = await originRepo.insertOneAsync(origin);
+
+  expect(originId).toBeTruthy();
+
+  origin.id = originId;
+
+  const crop = new Crop();
+  crop.origin = new Origin();
+  crop.origin.id = originId;
+  crop.year = random.number();
+
+  const cropId = await cropRepo.insertOneAsync(crop);
+
+  expect(cropId).toBeTruthy();
+
+  const readCrop = await cropRepo.findOneByIdAsync(cropId);
+
+  expect(readCrop).not.toBeNull();
+  expect(readCrop.year).toBe(crop.year);
+  expect(readCrop.origin.id).toBe(origin.id);
+  expect(readCrop.origin.estate).toBe(origin.estate);
+  expect(readCrop.origin.country).toBe(origin.country);
+  expect(readCrop.origin.altitude).toBe(origin.altitude);
+
+  const cropOriginPop = new CropOriginReferencePopulator(dbHelper.db);
+  const inMemCrop = new Crop();
+  
+  inMemCrop.origin = new Origin();
+  inMemCrop.origin.id = originId;
+
+  await cropOriginPop.populateReferenceAsync(inMemCrop);
+
+  expect(inMemCrop.origin.country).toBe(origin.country);
+  expect(inMemCrop.origin.estate).toBe(origin.estate);
+  expect(inMemCrop.origin.id).toBe(origin.id);
+  expect(inMemCrop.origin.altitude).toBe(origin.altitude);
+});

--- a/src/repository/mongo/crop/crop-origin-reference-populator.ts
+++ b/src/repository/mongo/crop/crop-origin-reference-populator.ts
@@ -1,0 +1,24 @@
+import { EntityRepositoryReferencePopulatorBase } from '../entities/references/entity-repository-reference-populator-base';
+import { Origin } from '@common/models/entities/origin/origin';
+import { Crop } from '@common/models/entities/crop/crop';
+import { Lazy } from '@common/lazy';
+import { OriginRepository } from '../origin/origin-repository';
+import { Db } from 'mongodb';
+
+export class CropOriginReferencePopulator extends EntityRepositoryReferencePopulatorBase<
+  Crop,
+  Origin
+> {
+  constructor(db: Db) {
+    super(new Lazy<OriginRepository>(() => new OriginRepository(db)));
+  }
+
+  protected getReferenceId(entity: Crop): string {
+    return entity.origin.id;
+  }
+  protected setReferenceObject(entity: Crop, ref: Origin): void {
+    Object.assign(entity.origin, {
+      ...ref,
+    });
+  }
+}

--- a/src/repository/mongo/crop/crop-repository.ts
+++ b/src/repository/mongo/crop/crop-repository.ts
@@ -1,7 +1,18 @@
-import { Crop } from "@common/models/entities/crop/crop";
-import { EntityRepositoryBase } from "../entities/entity-repository-base";
+import { Crop } from '@common/models/entities/crop/crop';
+import { EntityRepositoryBase } from '../entities/entity-repository-base';
+import { IEntityRepositoryReferencePopulator } from '../entities/references/ientity-repository-reference-populator';
+import { Db } from 'mongodb';
+import { CropOriginReferencePopulator } from './crop-origin-reference-populator';
 
 export class CropRepository extends EntityRepositoryBase<Crop> {
+  constructor(db: Db) {
+    super(db);
+
+    this.references = [
+      new CropOriginReferencePopulator(db)
+    ];
+  }
+  protected references: IEntityRepositoryReferencePopulator<Crop>[];
   protected readonly collectionName = Crop.collectionName;
   protected readonly factory: new () => Crop = Crop;
 }

--- a/src/repository/mongo/entities/references/entity-repository-reference-populator-base.ts
+++ b/src/repository/mongo/entities/references/entity-repository-reference-populator-base.ts
@@ -1,0 +1,31 @@
+import { Entity } from '@common/models/entities/entity';
+import { IMongoEntityRepository } from '../imongo-entity-repository';
+import { Lazy } from '@common/lazy';
+import { IEntityRepositoryReferencePopulator } from './ientity-repository-reference-populator';
+
+export abstract class EntityRepositoryReferencePopulatorBase<
+  TBaseEntity extends Entity,
+  TRefEntity extends Entity
+> implements IEntityRepositoryReferencePopulator<TBaseEntity> {
+  constructor(refRepo: Lazy<IMongoEntityRepository<TRefEntity>>) {
+    if (!refRepo) throw new Error(`Argument 'refRepo' is required.`);
+
+    this._refRepo = refRepo;
+  }
+
+  private readonly _refRepo: Lazy<IMongoEntityRepository<TRefEntity>>;
+
+  protected abstract getReferenceId(entity: TBaseEntity): string;
+  protected abstract setReferenceObject(
+    entity: TBaseEntity,
+    ref: TRefEntity,
+  ): void;
+
+  async populateReferenceAsync(entity: TBaseEntity): Promise<void> {
+    const refObject = await this._refRepo.value.findOneByIdAsync(
+      this.getReferenceId(entity),
+    );
+
+    if (refObject) this.setReferenceObject(entity, refObject);
+  }
+}

--- a/src/repository/mongo/entities/references/ientity-repository-reference-populator.ts
+++ b/src/repository/mongo/entities/references/ientity-repository-reference-populator.ts
@@ -1,0 +1,7 @@
+import { Entity } from '@common/models/entities/entity';
+
+export interface IEntityRepositoryReferencePopulator<
+  TBaseEntity extends Entity
+> {
+  populateReferenceAsync(entity: TBaseEntity): Promise<void>;
+}

--- a/src/repository/mongo/origin/origin-repository.ts
+++ b/src/repository/mongo/origin/origin-repository.ts
@@ -1,7 +1,9 @@
 import { EntityRepositoryBase } from "../entities/entity-repository-base";
 import { Origin } from "@common/models/entities/origin/origin";
+import { IEntityRepositoryReferencePopulator } from '../entities/references/ientity-repository-reference-populator';
 
 export class OriginRepository extends EntityRepositoryBase<Origin> {
+  protected references: IEntityRepositoryReferencePopulator<Origin>[] = null;
   protected readonly collectionName = Origin.collectionName;
   protected readonly factory: new () => Origin = Origin;
 }


### PR DESCRIPTION
# Summary

Added the capability to load mongo entity references in a schema-less fashion such that an entity with an id reference on the model can look up its references independently of other references on the referenced model. This should act in a chain like fashion where each repository declares its references.

- Added an interface for the reference populators.
- Added an abstract class that implements the interface method.
- Added a concrete implementation for the Crop -> Origin reference.
- Implemented the reference population in the read calls for the repository.