### PR TITLE
Refactoring api endpoints to use generic http handler factories

### DIFF
--- a/src/__spec__/api/api-test-suite.ts
+++ b/src/__spec__/api/api-test-suite.ts
@@ -5,18 +5,31 @@ import shortid from 'shortid';
 import { serverResource } from '../helpers';
 import * as request from 'request-promise-native';
 
+export enum SkipTestsInSuite {
+  Get,
+  Post,
+  Put,
+  Delete
+}
+
 export abstract class ApiTestSuite<TEntity extends Entity> {
+  constructor(skip: SkipTestsInSuite[] = []) {
+    this._skipped = skip;
+  }
+
   protected abstract factory(): TEntity;
   protected abstract routeName: string;
   protected abstract modelName: string;
   protected abstract assertPutEquals(model: TEntity, response: TEntity): void;
   protected abstract updateForPut(model: TEntity): TEntity;
 
+  private _skipped: SkipTestsInSuite[] = [];
+
   public init(): void {
-    this.initGet();
-    this.initPost();
-    this.initPut();
-    this.initDelete();
+    !this._skipped.includes(SkipTestsInSuite.Get) && this.initGet();
+    !this._skipped.includes(SkipTestsInSuite.Post) && this.initPost();
+    !this._skipped.includes(SkipTestsInSuite.Put) && this.initPut();
+    !this._skipped.includes(SkipTestsInSuite.Delete) && this.initDelete();
   }
 
   private initGet(): void {

--- a/src/__spec__/api/api-test-suite.ts
+++ b/src/__spec__/api/api-test-suite.ts
@@ -13,23 +13,18 @@ export enum SkipTestsInSuite {
 }
 
 export abstract class ApiTestSuite<TEntity extends Entity> {
-  constructor(skip: SkipTestsInSuite[] = []) {
-    this._skipped = skip;
-  }
-
   protected abstract factory(): TEntity;
   protected abstract routeName: string;
   protected abstract modelName: string;
   protected abstract assertPutEquals(model: TEntity, response: TEntity): void;
   protected abstract updateForPut(model: TEntity): TEntity;
-
-  private _skipped: SkipTestsInSuite[] = [];
+  protected skipped: SkipTestsInSuite[] = [];
 
   public init(): void {
-    !this._skipped.includes(SkipTestsInSuite.Get) && this.initGet();
-    !this._skipped.includes(SkipTestsInSuite.Post) && this.initPost();
-    !this._skipped.includes(SkipTestsInSuite.Put) && this.initPut();
-    !this._skipped.includes(SkipTestsInSuite.Delete) && this.initDelete();
+    !this.skipped.includes(SkipTestsInSuite.Get) && this.initGet();
+    !this.skipped.includes(SkipTestsInSuite.Post) && this.initPost();
+    !this.skipped.includes(SkipTestsInSuite.Put) && this.initPut();
+    !this.skipped.includes(SkipTestsInSuite.Delete) && this.initDelete();
   }
 
   private initGet(): void {

--- a/src/__spec__/api/api-tests.spec.ts
+++ b/src/__spec__/api/api-tests.spec.ts
@@ -1,7 +1,7 @@
-import { CropApiTestSuite } from './test-suites/crop';
-import { OriginApiTestSuite } from './test-suites/origin';
+import { CropsApiTestSuite } from './test-suites/crops';
+import { OriginsApiTestSuite } from './test-suites/origins';
 
 [
-  new CropApiTestSuite(),
-  new OriginApiTestSuite(),
+  new CropsApiTestSuite(),
+  new OriginsApiTestSuite(),
 ].forEach(tc => tc.init());

--- a/src/__spec__/api/api-tests.spec.ts
+++ b/src/__spec__/api/api-tests.spec.ts
@@ -1,7 +1,9 @@
 import { CropsApiTestSuite } from './test-suites/crops';
 import { OriginsApiTestSuite } from './test-suites/origins';
+import { RoastsApiTestSuite } from './test-suites/roasts';
 
 [
   new CropsApiTestSuite(),
   new OriginsApiTestSuite(),
+  new  RoastsApiTestSuite()
 ].forEach(tc => tc.init());

--- a/src/__spec__/api/test-suites/crops/index.ts
+++ b/src/__spec__/api/test-suites/crops/index.ts
@@ -4,7 +4,7 @@ import { Origin } from "@common/models/entities/origin/origin";
 import shortid from "shortid";
 import { random } from 'faker';
 
-export class CropApiTestSuite extends ApiTestSuite<Crop> {
+export class CropsApiTestSuite extends ApiTestSuite<Crop> {
   protected modelName = Crop.name;
   protected factory(): Crop {
     const crop = new Crop();

--- a/src/__spec__/api/test-suites/origins/index.ts
+++ b/src/__spec__/api/test-suites/origins/index.ts
@@ -3,7 +3,7 @@ import { ApiTestSuite } from "../../api-test-suite";
 import { Origin } from "@common/models/entities/origin/origin";
 import { random } from 'faker';
 
-export class OriginApiTestSuite extends ApiTestSuite<Origin> {
+export class OriginsApiTestSuite extends ApiTestSuite<Origin> {
   protected modelName = Origin.name;
   protected factory(): Origin {
     const origin = new Origin();

--- a/src/__spec__/api/test-suites/roasts/index.ts
+++ b/src/__spec__/api/test-suites/roasts/index.ts
@@ -1,0 +1,52 @@
+/* eslint-disable jest/no-standalone-expect */
+import { Roast } from "@common/models/entities/roast/roast";
+import { ApiTestSuite, SkipTestsInSuite } from "../../api-test-suite";
+import { random } from 'faker';
+import { Crop } from "@common/models/entities/crop/crop";
+import shortid from "shortid";
+
+export class RoastsApiTestSuite extends ApiTestSuite<Roast> {
+  constructor() {
+    // Skipping for now until I
+    // have the endpoints implemented
+    super([
+      SkipTestsInSuite.Delete,
+      SkipTestsInSuite.Post,
+      SkipTestsInSuite.Put
+    ]);
+  }
+
+  protected factory(): Roast {
+    const roast = new Roast();
+    roast.crop = new Crop();
+    roast.crop.id = shortid.generate();
+    roast.cuppingNotes = [
+      random.word(),
+      random.word()
+    ];
+    roast.description = random.words();
+    roast.duration = {
+      start: new Date(),
+      finish: new Date(),
+      firstCrack: new Date(),
+      secondCrack: null
+    };
+    roast.name = random.words();
+    roast.roastLevel = 'City+';
+
+    return roast;
+  }
+  protected routeName = 'roasts';
+  protected modelName: string = Roast.name;
+  protected assertPutEquals(model: Roast, response: Roast): void {
+    expect(model.name).toEqual(response.name);
+    expect(model.roastLevel).toEqual(response.roastLevel);
+  }
+  protected updateForPut(model: Roast): Roast {
+    model.name = random.words();
+    model.duration.secondCrack = new Date();
+    model.cuppingNotes.push(random.word());
+
+    return model;
+  }
+}

--- a/src/__spec__/api/test-suites/roasts/index.ts
+++ b/src/__spec__/api/test-suites/roasts/index.ts
@@ -6,16 +6,6 @@ import { Crop } from "@common/models/entities/crop/crop";
 import shortid from "shortid";
 
 export class RoastsApiTestSuite extends ApiTestSuite<Roast> {
-  constructor() {
-    // Skipping for now until I
-    // have the endpoints implemented
-    super([
-      SkipTestsInSuite.Delete,
-      SkipTestsInSuite.Post,
-      SkipTestsInSuite.Put
-    ]);
-  }
-
   protected factory(): Roast {
     const roast = new Roast();
     roast.crop = new Crop();

--- a/src/__spec__/repository/mongo/roast/roast-crop-reference-populator.spec.ts
+++ b/src/__spec__/repository/mongo/roast/roast-crop-reference-populator.spec.ts
@@ -1,0 +1,78 @@
+import { RoastCropReferencePopulator } from '@app/repository/mongo/roasts/roast-crop-reference-populator';
+import { OriginRepository } from '@app/repository/mongo/origin/origin-repository';
+import { CropRepository } from '@app/repository/mongo/crop/crop-repository';
+import { Origin } from '@common/models/entities/origin/origin';
+import { random } from 'faker';
+import { Crop } from '@common/models/entities/crop/crop';
+import { Roast } from '@common/models/entities/roast/roast';
+import { RoastRepository } from '@app/repository/mongo/roasts/roast-repository';
+import { InMemoryMongoHelper } from '@app/__spec__/helpers/mongo';
+
+const dbHelper = new InMemoryMongoHelper();
+
+beforeAll(async () => {
+  await dbHelper.start();
+});
+
+afterAll(async () => {
+  await dbHelper.cleanup();
+  await dbHelper.stop();
+});
+
+test(`It should successfully link a reference to an ${Origin.name} entity that is in the database and populate it`, async () => {
+  const originRepo = new OriginRepository(dbHelper.db);
+  const cropRepo = new CropRepository(dbHelper.db);
+  const roastRepo = new RoastRepository(dbHelper.db);
+  
+  const origin = new Origin();
+  origin.altitude = random.number();
+  origin.country = random.word();
+  origin.estate = random.word();
+  
+  const originId = await originRepo.insertOneAsync(origin);
+
+  expect(originId).toBeTruthy();
+
+  origin.id = originId;
+
+  const crop = new Crop();
+  crop.origin = new Origin();
+  crop.origin.id = originId;
+  crop.year = random.number();
+
+  const cropId = await cropRepo.insertOneAsync(crop);
+
+  const roast = new Roast();
+  roast.crop = new Crop();
+  roast.crop.id = cropId;
+  roast.cuppingNotes = ['Blueberry', 'Honey', 'Chocolate', 'Lemon Zest'];
+  roast.description = 'A decadent, fruity, complex coffee with astounding blueberry flavors.';
+  roast.duration = {
+    start: new Date(),
+    finish: new Date(),
+    firstCrack: new Date(),
+    secondCrack: null
+  };
+  roast.name = 'Ethiopia Guji from Bodhi Leaf';
+  roast.roastLevel = 'City+';
+
+  const roastId = await roastRepo.insertOneAsync(roast);
+
+  expect(roastId).toBeTruthy();
+
+  const readFromDbRoast = await roastRepo.findOneByIdAsync(roastId);
+
+  expect(readFromDbRoast.crop.year).toEqual(crop.year);
+  expect(readFromDbRoast.crop.origin.estate).toEqual(origin.estate);
+
+  const inMemoryRoast = new Roast();
+  inMemoryRoast.crop = new Crop();
+  inMemoryRoast.crop.id = cropId;
+
+  const refPopulator = new RoastCropReferencePopulator(dbHelper.db);
+
+  await refPopulator.populateReferenceAsync(inMemoryRoast);
+
+  expect(inMemoryRoast.crop.year).toEqual(crop.year);
+  expect(inMemoryRoast.crop.origin.estate).toEqual(origin.estate);
+});

--- a/src/api/base/delete.ts
+++ b/src/api/base/delete.ts
@@ -1,0 +1,43 @@
+import { RepositoryFactory, ApiHttpHandler, ApiResponse } from './types';
+import { Entity } from '@common/models/entities/entity';
+import { Request, Response, NextFunction } from 'express';
+import { HttpStatusError } from '@app/errors/http/http-status-error';
+import { using } from '@common/using';
+import { BAD_REQUEST, OK, NOT_FOUND, INTERNAL_SERVER_ERROR } from 'http-status-codes';
+import { RepositoryContainer } from '@app/repository/mongo/repository-container';
+
+export function createDeleteHandler<TEntity extends Entity>(
+  repoFactory: RepositoryFactory<TEntity>,
+): ApiHttpHandler {
+  return async function deleteEntity(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): ApiResponse {
+    if (!req.params.id) {
+      return next(new HttpStatusError(`No id was supplied for the delete operation`, BAD_REQUEST));
+    }
+  
+    const [deleteResult, error] = await using(new RepositoryContainer(repoFactory), async container => {
+      const repo = await container.create();
+      const result = await repo.deleteOneAsync(req.params.id);
+  
+      return result;
+    });
+  
+    // Item was deleted.
+    if (deleteResult) {
+      return res.sendStatus(OK);
+    }
+  
+    // Item was not deleted, and there was no error.
+    // Safe to assume it was not found.
+    if (!deleteResult && !error) {
+      return next(new HttpStatusError(`The resource was not found to delete`, NOT_FOUND));
+    }
+    
+    // Fallthrough
+    // Unexpected error.
+    return next(new HttpStatusError(`Something went wrong while deleting the resource`, INTERNAL_SERVER_ERROR, error)); 
+  };
+}

--- a/src/api/base/get.ts
+++ b/src/api/base/get.ts
@@ -1,0 +1,78 @@
+import { Entity } from '@common/models/entities/entity';
+import { Request, Response, NextFunction } from 'express';
+import { HttpStatusError } from '@app/errors/http/http-status-error';
+import { RepositoryContainer } from '@app/repository/mongo/repository-container';
+import { using } from '@common/using';
+import { Db } from 'mongodb';
+import { EntityRepositoryBase } from '@app/repository/mongo/entities/entity-repository-base';
+import {
+  INTERNAL_SERVER_ERROR,
+  BAD_REQUEST,
+  NOT_FOUND,
+} from 'http-status-codes';
+import { ApiHttpHandler, ApiResponse } from './types';
+
+export function createGetManyHandler<TEntity extends Entity>(
+  repoFactory: new (db: Db) => EntityRepositoryBase<TEntity>,
+): ApiHttpHandler {
+  return async function getManyOfEntity(
+    _: Request,
+    res: Response,
+    next: NextFunction,
+  ): ApiResponse {
+    const [items, error] = await using(
+      new RepositoryContainer(repoFactory),
+      async (container) => {
+        const repo = await container.create();
+
+        return repo.findAllAsync();
+      },
+    );
+
+    if (error) {
+      return next(
+        new HttpStatusError(
+          `Something went wrong when retrieving items`,
+          INTERNAL_SERVER_ERROR,
+          error,
+        ),
+      );
+    }
+
+    return res.send(items);
+  };
+}
+
+export function createGetOneHandler<TEntity extends Entity>(
+  repoFactory: new (db: Db) => EntityRepositoryBase<TEntity>,
+): ApiHttpHandler {
+  return async function getOne(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): ApiResponse {
+    if (!req.params.id) {
+      return next(
+        new HttpStatusError(
+          `Expected an item id, but got nothing`,
+          BAD_REQUEST,
+        ),
+      );
+    }
+
+    const [item, error] = await using(
+      new RepositoryContainer(repoFactory),
+      async (container) => {
+        const repo = await container.create();
+
+        return repo.findOneByIdAsync(req.params.id);
+      },
+    );
+
+    if (!item) {
+      return next(new HttpStatusError(`Item not found`, NOT_FOUND, error));
+    }
+
+    return res.send(item);
+  };
+}

--- a/src/api/base/get.ts
+++ b/src/api/base/get.ts
@@ -3,17 +3,15 @@ import { Request, Response, NextFunction } from 'express';
 import { HttpStatusError } from '@app/errors/http/http-status-error';
 import { RepositoryContainer } from '@app/repository/mongo/repository-container';
 import { using } from '@common/using';
-import { Db } from 'mongodb';
-import { EntityRepositoryBase } from '@app/repository/mongo/entities/entity-repository-base';
 import {
   INTERNAL_SERVER_ERROR,
   BAD_REQUEST,
   NOT_FOUND,
 } from 'http-status-codes';
-import { ApiHttpHandler, ApiResponse } from './types';
+import { ApiHttpHandler, ApiResponse, RepositoryFactory } from './types';
 
 export function createGetManyHandler<TEntity extends Entity>(
-  repoFactory: new (db: Db) => EntityRepositoryBase<TEntity>,
+  repoFactory: RepositoryFactory<TEntity>,
 ): ApiHttpHandler {
   return async function getManyOfEntity(
     _: Request,
@@ -44,7 +42,7 @@ export function createGetManyHandler<TEntity extends Entity>(
 }
 
 export function createGetOneHandler<TEntity extends Entity>(
-  repoFactory: new (db: Db) => EntityRepositoryBase<TEntity>,
+  repoFactory: RepositoryFactory<TEntity>,
 ): ApiHttpHandler {
   return async function getOne(
     req: Request,

--- a/src/api/base/put.ts
+++ b/src/api/base/put.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction } from "express";
+import { OK, BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND } from "http-status-codes";
+import { RepositoryContainer } from "@app/repository/mongo/repository-container";
+import { HttpStatusError } from "@app/errors/http/http-status-error";
+import { using } from "@common/using";
+import { ApiHttpHandler, ApiResponse, RepositoryFactory } from "./types";
+import { Entity } from "@common/models/entities/entity";
+
+export function createPutHandler<TEntity extends Entity>(
+  repoFactory: RepositoryFactory<TEntity>
+): ApiHttpHandler {
+  return async function putEntity(req: Request, res: Response, next: NextFunction): ApiResponse {
+    if (!req.params.id) {
+      return next(new HttpStatusError(`Expected a resource id but didn't get one.`, BAD_REQUEST));
+    }
+  
+    if (!req.body) {
+      return next(new HttpStatusError(`Expected a resource for update, but didn't get one.`, BAD_REQUEST));
+    }
+  
+    const [updateResult, error] = await using(new RepositoryContainer(repoFactory), async container => {
+      const cropRepo = await container.create();
+      const updateResult = await cropRepo.updateOneAsync(req.params.id, req.body);
+  
+      return updateResult;
+    });
+  
+    // Item was updated.
+    if (updateResult) {
+      return res.sendStatus(OK);
+    }
+  
+    // No update made, and error is empty; this should mean
+    // that the resource was not present in the database.
+    if (!updateResult && !error) {
+      return next(new HttpStatusError(`The requested resource was not found`, NOT_FOUND));
+    }
+  
+    // Fallthrough - unknown error.
+    return next(new HttpStatusError(`Something went wrong while updating the resource.`, INTERNAL_SERVER_ERROR, error));
+  };
+}

--- a/src/api/base/types.d.ts
+++ b/src/api/base/types.d.ts
@@ -1,0 +1,12 @@
+import { NextFunction, Response, Request } from 'express';
+import { Db } from 'mongodb';
+import { Entity } from '@common/models/entities/entity';
+import { EntityRepositoryBase } from '@app/repository/mongo/entities/entity-repository-base';
+
+export type ApiHttpHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<Response<unknown> | void>;
+export type ApiResponse = Promise<Response<unknown> | void>;
+export type RepositoryFactory<TEntity extends Entity> = new (db: Db) => EntityRepositoryBase<TEntity>;

--- a/src/api/base/types.ts
+++ b/src/api/base/types.ts
@@ -1,8 +1,0 @@
-import { NextFunction, Response, Request } from 'express';
-
-export type ApiHttpHandler = (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => Promise<Response<unknown> | void>;
-export type ApiResponse = Promise<Response<unknown> | void>;

--- a/src/api/base/types.ts
+++ b/src/api/base/types.ts
@@ -1,0 +1,8 @@
+import { NextFunction, Response, Request } from 'express';
+
+export type ApiHttpHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => Promise<Response<unknown> | void>;
+export type ApiResponse = Promise<Response<unknown> | void>;

--- a/src/api/crops/delete.ts
+++ b/src/api/crops/delete.ts
@@ -1,34 +1,4 @@
-import { Request, Response, NextFunction } from "express";
-import { HttpStatusError } from "@app/errors/http/http-status-error";
-import { BAD_REQUEST, INTERNAL_SERVER_ERROR, OK, NOT_FOUND } from "http-status-codes";
-import { using } from "@common/using";
-import { RepositoryContainer } from "@app/repository/mongo/repository-container";
+import { createDeleteHandler } from "../base/delete";
 import { CropRepository } from "@app/repository/mongo/crop/crop-repository";
 
-export async function deleteCrop(req: Request, res: Response, next: NextFunction): Promise<Response<unknown> | void> {
-  if (!req.params.id) {
-    return next(new HttpStatusError(`No id was supplied for the delete operation`, BAD_REQUEST));
-  }
-
-  const [deleteResult, error] = await using(new RepositoryContainer(CropRepository), async container => {
-    const repo = await container.create();
-    const result = await repo.deleteOneAsync(req.params.id);
-
-    return result;
-  });
-
-  // Item was deleted.
-  if (deleteResult) {
-    return res.sendStatus(OK);
-  }
-
-  // Item was not deleted, and there was no error.
-  // Safe to assume it was not found.
-  if (!deleteResult && !error) {
-    return next(new HttpStatusError(`The resource was not found to delete`, NOT_FOUND));
-  }
-  
-  // Fallthrough
-  // Unexpected error.
-  return next(new HttpStatusError(`Something went wrong while deleting the resource`, INTERNAL_SERVER_ERROR, error)); 
-}
+export const deleteCrop = createDeleteHandler(CropRepository);

--- a/src/api/crops/get.ts
+++ b/src/api/crops/get.ts
@@ -1,38 +1,5 @@
-import { Request, Response, NextFunction } from 'express';
-import { using } from '@common/using';
-import { RepositoryContainer } from '@app/repository/mongo/repository-container';
-import { CropRepository } from '@app/repository/mongo/crop/crop-repository';
-import { HttpStatusError } from '@app/errors/http/http-status-error';
-import { BAD_REQUEST, NOT_FOUND, INTERNAL_SERVER_ERROR } from 'http-status-codes';
+import { createGetManyHandler, createGetOneHandler } from "../base/get";
+import { CropRepository } from "@app/repository/mongo/crop/crop-repository";
 
-export async function getCrops(_: Request, res: Response, next: NextFunction): Promise<Response<unknown> | void> {
-  const [crops, error] = await using(new RepositoryContainer(CropRepository), async container => {
-    const repo = await container.create();
-
-    return repo.findAllAsync();
-  });
-
-  if (error) {
-    return next(new HttpStatusError(`Something went wrong when retrieving the resources`, INTERNAL_SERVER_ERROR, error));
-  }
-
-  return res.send(crops);
-}
-
-export async function getCrop(req: Request, res: Response, next: NextFunction): Promise<Response<unknown> | void> {
-  if (!req.params.id) {
-    return next(new HttpStatusError(`Expected a resource id, but got nothing`, BAD_REQUEST));
-  }
-
-  const [crop, error] = await using(new RepositoryContainer(CropRepository), async container => {
-    const repo = await container.create();
-
-    return repo.findOneByIdAsync(req.params.id);
-  });
-
-  if (!crop) {
-    return next(new HttpStatusError(`Resource not found`, NOT_FOUND, error));
-  }
-
-  return res.send(crop);
-}
+export const getCrops = createGetManyHandler(CropRepository);
+export const getCrop = createGetOneHandler(CropRepository);

--- a/src/api/crops/post.ts
+++ b/src/api/crops/post.ts
@@ -1,48 +1,5 @@
-import { Request, Response, NextFunction } from 'express';
-import { BAD_REQUEST, INTERNAL_SERVER_ERROR } from 'http-status-codes';
-import { RepositoryContainer } from '@app/repository/mongo/repository-container';
-import { CropRepository } from '@app/repository/mongo/crop/crop-repository';
-import { Crop } from '@common/models/entities/crop/crop';
-import { HttpStatusError } from '@app/errors/http/http-status-error';
-import { using } from '@common/using';
+import { createPostHandler } from "../base/post";
+import { CropRepository } from "@app/repository/mongo/crop/crop-repository";
+import { Crop } from "@common/models/entities/crop/crop";
 
-export async function postCrop(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<Response<unknown> | void> {
-  if (!req.body) {
-    return next(
-      new HttpStatusError(`No model was provided for creation`, BAD_REQUEST),
-    );
-  }
-
-  if (!Crop.isValid(req.body)) {
-    return next(new HttpStatusError(`The model is invalid.`, BAD_REQUEST));
-  }
-
-  const [inserted, error] = await using(
-    new RepositoryContainer(CropRepository),
-    async (container) => {
-      const cropRepo = await container.create();
-      const id = await cropRepo.insertOneAsync(req.body);
-
-      if (id) {
-        const inserted = await cropRepo.findOneByIdAsync(id);
-        return inserted;
-      }
-    },
-  );
-
-  if (!inserted) {
-    return next(
-      new HttpStatusError(
-        `An error occurred while creating the resource. Please try again.`,
-        INTERNAL_SERVER_ERROR,
-        error,
-      ),
-    );
-  }
-
-  return res.send(inserted);
-}
+export const postCrop = createPostHandler(CropRepository, Crop.isValid);

--- a/src/api/crops/put.ts
+++ b/src/api/crops/put.ts
@@ -1,37 +1,4 @@
-import { Request, Response, NextFunction } from "express";
-import { OK, BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND } from "http-status-codes";
+import { createPutHandler } from "../base/put";
 import { CropRepository } from "@app/repository/mongo/crop/crop-repository";
-import { RepositoryContainer } from "@app/repository/mongo/repository-container";
-import { HttpStatusError } from "@app/errors/http/http-status-error";
-import { using } from "@common/using";
 
-export async function putCrop(req: Request, res: Response, next: NextFunction): Promise<Response<unknown> | void> {
-  if (!req.params.id) {
-    return next(new HttpStatusError(`Expected a resource id but didn't get one.`, BAD_REQUEST));
-  }
-
-  if (!req.body) {
-    return next(new HttpStatusError(`Expected a resource for update, but didn't get one.`, BAD_REQUEST));
-  }
-
-  const [updateResult, error] = await using(new RepositoryContainer(CropRepository), async container => {
-    const cropRepo = await container.create();
-    const updateResult = await cropRepo.updateOneAsync(req.params.id, req.body);
-
-    return updateResult;
-  });
-
-  // Item was updated.
-  if (updateResult) {
-    return res.sendStatus(OK);
-  }
-
-  // No update made, and error is empty; this should mean
-  // that the resource was not present in the database.
-  if (!updateResult && !error) {
-    return next(new HttpStatusError(`The requested resource was not found`, NOT_FOUND));
-  }
-
-  // Fallthrough - unknown error.
-  return next(new HttpStatusError(`Something went wrong while updating the resource.`, INTERNAL_SERVER_ERROR, error));
-}
+export const putCrop = createPutHandler(CropRepository);

--- a/src/api/origins/delete.ts
+++ b/src/api/origins/delete.ts
@@ -1,34 +1,4 @@
-import { Request, Response, NextFunction } from "express";
-import { OK, BAD_REQUEST, NOT_FOUND, INTERNAL_SERVER_ERROR } from "http-status-codes";
-import { HttpStatusError } from "@app/errors/http/http-status-error";
-import { using } from "@common/using";
-import { RepositoryContainer } from "@app/repository/mongo/repository-container";
+import { createDeleteHandler } from "../base/delete";
 import { OriginRepository } from "@app/repository/mongo/origin/origin-repository";
 
-export async function deleteOrigin(req: Request, res: Response, next: NextFunction): Promise<Response<unknown> | void> {
-  if (!req.params.id) {
-    return next(new HttpStatusError(`No id was supplied for the delete operation`, BAD_REQUEST));
-  }
-
-  const [deleteResult, error] = await using(new RepositoryContainer(OriginRepository), async container => {
-    const repo = await container.create();
-    const result = await repo.deleteOneAsync(req.params.id);
-
-    return result;
-  });
-
-  // Item was deleted.
-  if (deleteResult) {
-    return res.sendStatus(OK);
-  }
-
-  // Item was not deleted, and there was no error.
-  // Safe to assume it was not found.
-  if (!deleteResult && !error) {
-    return next(new HttpStatusError(`The resource was not found to delete`, NOT_FOUND));
-  }
-  
-  // Fallthrough
-  // Unexpected error.
-  return next(new HttpStatusError(`Something went wrong while deleting the resource`, INTERNAL_SERVER_ERROR, error)); 
-}
+export const deleteOrigin = createDeleteHandler(OriginRepository);

--- a/src/api/origins/get.ts
+++ b/src/api/origins/get.ts
@@ -1,38 +1,5 @@
-import { Request, Response, NextFunction } from "express";
-import { using } from "@common/using";
-import { RepositoryContainer } from "@app/repository/mongo/repository-container";
 import { OriginRepository } from "@app/repository/mongo/origin/origin-repository";
-import { INTERNAL_SERVER_ERROR, BAD_REQUEST, NOT_FOUND } from "http-status-codes";
-import { HttpStatusError } from "@app/errors/http/http-status-error";
+import { createGetManyHandler, createGetOneHandler } from "../base/get";
 
-export async function getOrigins(req: Request, res: Response, next: NextFunction): Promise<Response<unknown> | void> {
-  const [origins, error] = await using(new RepositoryContainer(OriginRepository), async container => {
-    const repo = await container.create();
-
-    return repo.findAllAsync();
-  });
-
-  if (error) {
-    return next(new HttpStatusError(`Something went wrong when retrieving Origins`, INTERNAL_SERVER_ERROR, error));
-  }
-
-  return res.send(origins);
-}
-
-export async function getOrigin(req: Request, res: Response, next: NextFunction): Promise<Response<unknown> | void> {
-  if (!req.params.id) {
-    return next(new HttpStatusError(`Expected an Origin id, but got nothing`, BAD_REQUEST));
-  }
-
-  const [origin, error] = await using(new RepositoryContainer(OriginRepository), async container => {
-    const repo = await container.create();
-
-    return repo.findOneByIdAsync(req.params.id);
-  });
-
-  if (!origin) {
-    return next(new HttpStatusError(`Origin not found`, NOT_FOUND, error));
-  }
-
-  return res.send(origin);
-}
+export const getOrigins = createGetManyHandler(OriginRepository);
+export const getOrigin = createGetOneHandler(OriginRepository);

--- a/src/api/origins/post.ts
+++ b/src/api/origins/post.ts
@@ -1,48 +1,5 @@
-import { Request, Response, NextFunction } from 'express';
-import { OriginRepository } from '@app/repository/mongo/origin/origin-repository';
-import { RepositoryContainer } from '@app/repository/mongo/repository-container';
-import { HttpStatusError } from '@app/errors/http/http-status-error';
-import { BAD_REQUEST, INTERNAL_SERVER_ERROR } from 'http-status-codes';
-import { using } from '@common/using';
-import { Origin } from '@common/models/entities/origin/origin';
+import { createPostHandler } from "../base/post";
+import { OriginRepository } from "@app/repository/mongo/origin/origin-repository";
+import { Origin } from "@common/models/entities/origin/origin";
 
-export async function postOrigin(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<Response<unknown> | void> {
-  if (!req.body) {
-    return next(
-      new HttpStatusError(`No model was provided for creation`, BAD_REQUEST),
-    );
-  }
-
-  if (!Origin.isValid(req.body)) {
-    return next(new HttpStatusError(`The model is invalid.`, BAD_REQUEST));
-  }
-
-  const [inserted, error] = await using(
-    new RepositoryContainer(OriginRepository),
-    async (container) => {
-      const originRepo = await container.create();
-      const id = await originRepo.insertOneAsync(req.body);
-
-      if (id) {
-        const inserted = await originRepo.findOneByIdAsync(id);
-        return inserted;
-      }
-    },
-  );
-
-  if (!inserted) {
-    return next(
-      new HttpStatusError(
-        `An error occurred while creating the resource. Please try again.`,
-        INTERNAL_SERVER_ERROR,
-        error,
-      ),
-    );
-  }
-
-  return res.send(inserted);
-}
+export const postOrigin = createPostHandler(OriginRepository, Origin.isValid);

--- a/src/api/origins/put.ts
+++ b/src/api/origins/put.ts
@@ -1,37 +1,4 @@
-import { Request, Response, NextFunction } from "express";
-import { OK, BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND } from "http-status-codes";
-import { RepositoryContainer } from "@app/repository/mongo/repository-container";
-import { HttpStatusError } from "@app/errors/http/http-status-error";
-import { using } from "@common/using";
+import { createPutHandler } from "../base/put";
 import { OriginRepository } from "@app/repository/mongo/origin/origin-repository";
 
-export async function putOrigin(req: Request, res: Response, next: NextFunction): Promise<Response<unknown> | void> {
-  if (!req.params.id) {
-    return next(new HttpStatusError(`Expected a resource id but didn't get one.`, BAD_REQUEST));
-  }
-
-  if (!req.body) {
-    return next(new HttpStatusError(`Expected a resource for update, but didn't get one.`, BAD_REQUEST));
-  }
-
-  const [updateResult, error] = await using(new RepositoryContainer(OriginRepository), async container => {
-    const originRepo = await container.create();
-    const updateResult = await originRepo.updateOneAsync(req.params.id, req.body);
-
-    return updateResult;
-  });
-
-  // Item was updated.
-  if (updateResult) {
-    return res.sendStatus(OK);
-  }
-
-  // No update made, and error is empty; this should mean
-  // that the resource was not present in the database.
-  if (!updateResult && !error) {
-    return next(new HttpStatusError(`The requested resource was not found`, NOT_FOUND));
-  }
-
-  // Fallthrough - unknown error.
-  return next(new HttpStatusError(`Something went wrong while updating the resource.`, INTERNAL_SERVER_ERROR, error));
-}
+export const putOrigin = createPutHandler(OriginRepository);

--- a/src/api/roasts/delete.ts
+++ b/src/api/roasts/delete.ts
@@ -1,5 +1,4 @@
-import { Request, Response } from "express";
+import { createDeleteHandler } from "../base/delete";
+import { RoastRepository } from "@app/repository/mongo/roasts/roast-repository";
 
-export function deleteRoast(req: Request, res: Response): void {
-  res.send(200);
-}
+export const deleteRoast = createDeleteHandler(RoastRepository);

--- a/src/api/roasts/get.ts
+++ b/src/api/roasts/get.ts
@@ -1,10 +1,5 @@
-import { Response, Request } from 'express';
-import { Roast } from '@common/models/entities/roast/roast';
+import { createGetManyHandler, createGetOneHandler } from "../base/get";
+import { RoastRepository } from "@app/repository/mongo/roasts/roast-repository";
 
-export function getRoasts(req: Request, res: Response): void {
-  res.send([new Roast()]);
-}
-
-export function getRoast(req: Request, res: Response): void {
-  res.send(new Roast());
-}
+export const getRoasts = createGetManyHandler(RoastRepository);
+export const getRoast = createGetOneHandler(RoastRepository);

--- a/src/api/roasts/post.ts
+++ b/src/api/roasts/post.ts
@@ -1,6 +1,5 @@
-import { OK } from 'http-status-codes';
-import { Response, Request } from 'express';
+import { createPostHandler } from "../base/post";
+import { RoastRepository } from "@app/repository/mongo/roasts/roast-repository";
+import { Roast } from "@common/models/entities/roast/roast";
 
-export function postRoast(req: Request, res: Response): void {
-  res.send(OK);
-}
+export const postRoast = createPostHandler(RoastRepository, Roast.isValid);

--- a/src/api/roasts/put.ts
+++ b/src/api/roasts/put.ts
@@ -1,6 +1,4 @@
-import { OK } from 'http-status-codes';
-import { Response, Request } from 'express';
+import { createPutHandler } from "../base/put";
+import { RoastRepository } from "@app/repository/mongo/roasts/roast-repository";
 
-export function putRoast(req: Request, res: Response): void {
-  res.send(OK);
-}
+export const putRoast = createPutHandler(RoastRepository);

--- a/src/repository/mongo/roasts/roast-crop-reference-populator.ts
+++ b/src/repository/mongo/roasts/roast-crop-reference-populator.ts
@@ -1,0 +1,25 @@
+import { EntityRepositoryReferencePopulatorBase } from "../entities/references/entity-repository-reference-populator-base";
+import { Roast } from "@common/models/entities/roast/roast";
+import { Crop } from "@common/models/entities/crop/crop";
+import { CropRepository } from "../crop/crop-repository";
+import { Lazy } from "@common/lazy";
+import { Db } from "mongodb";
+
+export class RoastCropReferencePopulator extends EntityRepositoryReferencePopulatorBase<
+  Roast,
+  Crop
+> {
+  constructor(db: Db) {
+    super(new Lazy<CropRepository>(() => new CropRepository(db)));
+  }
+
+  protected getReferenceId(entity: Roast): string {
+    return entity.crop.id;
+  }
+
+  protected setReferenceObject(entity: Roast, ref: Crop): void {
+    Object.assign(entity.crop, {
+      ...ref
+    });
+  }
+}

--- a/src/repository/mongo/roasts/roast-repository.ts
+++ b/src/repository/mongo/roasts/roast-repository.ts
@@ -1,0 +1,19 @@
+import { EntityRepositoryBase } from '../entities/entity-repository-base';
+import { IEntityRepositoryReferencePopulator } from '../entities/references/ientity-repository-reference-populator';
+import { Db } from 'mongodb';
+import { Roast } from '@common/models/entities/roast/roast';
+import { RoastCropReferencePopulator } from './roast-crop-reference-populator';
+
+export class RoastRepository extends EntityRepositoryBase<Roast> {
+  constructor(db: Db) {
+    super(db);
+
+    this.references = [
+      new RoastCropReferencePopulator(db)
+    ];
+  }
+  protected references: IEntityRepositoryReferencePopulator<Roast>[];
+  protected readonly collectionName = Roast.collectionName;
+  protected readonly factory: new () => Roast = Roast;
+}
+


### PR DESCRIPTION
# Summary

- Introduced new concept of generic HTTP handlers for all entities.
- Refactored the endpoints to use the factories instead of being WET.
  - This will encourage our controller logic to be DRY.
- Updated Roast model to accommodate endpoints.
- Added validation method for Roast.
- Added api test suite for new Roast endpoints.
- Added reference populator for roasts and crops.